### PR TITLE
Fix stale KernelSU root detection

### DIFF
--- a/app/src/main/kotlin/com/alex193a/rootmypixel/feature/install/InstallViewModel.kt
+++ b/app/src/main/kotlin/com/alex193a/rootmypixel/feature/install/InstallViewModel.kt
@@ -19,6 +19,7 @@ import com.alex193a.rootmypixel.domain.usecase.DownloadPayloadsUseCase
 import com.alex193a.rootmypixel.domain.usecase.ResolveTargetUseCase
 import com.alex193a.rootmypixel.shizuku.ExploitService
 import com.alex193a.rootmypixel.shizuku.IExploitService
+import com.alex193a.rootmypixel.shizuku.KernelSuDetector
 import com.alex193a.rootmypixel.utils.NativeProbe
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -67,7 +68,7 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
             try {
                 val probe = NativeProbe.run()
                 val deviceInfo = NativeProbe.readDeviceSnapshot()
-                if (NativeProbe.isKernelSuActive()) {
+                if (NativeProbe.isKernelSuActive() || KernelSuDetector.isActive(app)) {
                     mutableState.value = InstallUiState(
                         phase = InstallPhase.Installed,
                         message = app.getString(R.string.status_ksu_active),
@@ -374,12 +375,13 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
         }
 
         // 4. Verify KSU is actually loaded (check multiple paths)
-        var ksuActive = false
+        var ksuActive = lateResult.code == 0 &&
+            lateResult.output.contains("KernelSU control verified")
         for (i in 1..10) {
+            if (ksuActive) break
             val check = runHelper(helper, "-c",
                 "test -e /dev/kernelsu && echo KSU_OK || " +
                 "test -e /sys/kernel/kernelsu && echo KSU_OK || " +
-                "test -e /data/adb/ksu && echo KSU_OK || " +
                 "echo KSU_NOT_FOUND")
             if (check.output.contains("KSU_OK")) {
                 appendLog("[+] KernelSU verified (attempt $i): ${check.output.take(60)}")

--- a/app/src/main/kotlin/com/alex193a/rootmypixel/feature/main/MainViewModel.kt
+++ b/app/src/main/kotlin/com/alex193a/rootmypixel/feature/main/MainViewModel.kt
@@ -17,6 +17,7 @@ import com.alex193a.rootmypixel.domain.model.InstallPhase
 import com.alex193a.rootmypixel.domain.model.InstallUiState
 import com.alex193a.rootmypixel.domain.usecase.ResolveTargetUseCase
 import com.alex193a.rootmypixel.feature.install.InstallActivity
+import com.alex193a.rootmypixel.shizuku.KernelSuDetector
 import com.alex193a.rootmypixel.utils.NativeProbe
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -107,7 +108,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                 mutableReSukiSuInstalled.value = app.packageManager
                     .getLaunchIntentForPackage("com.resukisu.resukisu") != null
                 val probe = NativeProbe.run()
-                if (NativeProbe.isKernelSuActive()) {
+                if (NativeProbe.isKernelSuActive() || KernelSuDetector.isActive(app)) {
                     mutableState.value = InstallUiState(
                         phase = InstallPhase.Installed,
                         message = app.getString(R.string.status_ksu_active),

--- a/app/src/main/kotlin/com/alex193a/rootmypixel/shizuku/KernelSuDetector.kt
+++ b/app/src/main/kotlin/com/alex193a/rootmypixel/shizuku/KernelSuDetector.kt
@@ -1,0 +1,57 @@
+package com.alex193a.rootmypixel.shizuku
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.ServiceConnection
+import android.content.pm.PackageManager
+import android.os.IBinder
+import rikka.shizuku.Shizuku
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+object KernelSuDetector {
+    fun isActive(context: Context): Boolean {
+        val available = runCatching {
+            Shizuku.pingBinder() &&
+                Shizuku.isPreV11().not() &&
+                Shizuku.getUid() == 2000 &&
+                Shizuku.checkSelfPermission() == PackageManager.PERMISSION_GRANTED
+        }.getOrDefault(false)
+        if (!available) return false
+
+        val args = Shizuku.UserServiceArgs(
+            ComponentName(context.packageName, ExploitService::class.java.name)
+        )
+            .daemon(false)
+            .processNameSuffix("exploit_service")
+            .version(1)
+        val connected = CountDownLatch(1)
+        var service: IExploitService? = null
+        val connection = object : ServiceConnection {
+            override fun onServiceConnected(name: ComponentName?, binder: IBinder?) {
+                service = IExploitService.Stub.asInterface(binder)
+                connected.countDown()
+            }
+
+            override fun onServiceDisconnected(name: ComponentName?) {
+                service = null
+            }
+        }
+
+        return try {
+            Shizuku.bindUserService(args, connection)
+            connected.await(SERVICE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            val output = service?.exec(
+                "/data/local/tmp/ksud-pixel debug version 2>/dev/null || true"
+            ).orEmpty()
+            ROOT_VERSION.find(output)?.groupValues?.get(1)?.toIntOrNull()?.let { it > 0 } == true
+        } catch (_: Exception) {
+            false
+        } finally {
+            runCatching { Shizuku.unbindUserService(args, connection, true) }
+        }
+    }
+
+    private const val SERVICE_TIMEOUT_SECONDS = 5L
+    private val ROOT_VERSION = Regex("Kernel Version: ([0-9]+)")
+}

--- a/app/src/main/kotlin/com/alex193a/rootmypixel/utils/NativeProbe.kt
+++ b/app/src/main/kotlin/com/alex193a/rootmypixel/utils/NativeProbe.kt
@@ -21,9 +21,7 @@ object NativeProbe {
      */
     fun isKernelSuActive(): Boolean {
         return File("/dev/kernelsu").exists() ||
-            File("/sys/kernel/kernelsu").exists() ||
-            File("/data/adb/ksu").exists() ||
-            File("/data/adb/ksu/bin/ksu").exists()
+            File("/sys/kernel/kernelsu").exists()
     }
 
     /**


### PR DESCRIPTION
Stops treating persistent /data/adb/ksu files as proof that KernelSU is active. Root state is now checked through a KernelSU version probe using the existing Shizuku UserService.