### PR TITLE
fix: stop root detection from killing the exploit and failing good loads

### DIFF
--- a/app/src/main/kotlin/com/alex193a/rootmypixel/feature/install/InstallViewModel.kt
+++ b/app/src/main/kotlin/com/alex193a/rootmypixel/feature/install/InstallViewModel.kt
@@ -24,6 +24,7 @@ import com.alex193a.rootmypixel.utils.NativeProbe
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -129,7 +130,12 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
                 phase = InstallPhase.Checking,
                 probeOutput = mutableState.value.probeOutput,
             )
+            KernelSuDetector.beginInstall()
             try {
+                // Probing is blocking, so cancel() does not stop it — join, or it
+                // tears its Shizuku service down while the exploit is running.
+                discoveryJob?.cancelAndJoin()
+
                 setPhase(InstallPhase.Checking, app.getString(R.string.status_checking))
                 val deviceInfo = NativeProbe.readDeviceSnapshot()
 
@@ -195,6 +201,8 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
                 if (error is CancellationException) throw error
                 appendLog("[-] ${error.message ?: error.javaClass.simpleName}")
                 setPhase(InstallPhase.Failed, app.getString(R.string.status_install_failed))
+            } finally {
+                KernelSuDetector.endInstall()
             }
         }
     }
@@ -336,7 +344,7 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
 
     private fun installKernelSu(payloads: VerifiedPayloads) {
         val ksudSource = payloads.kernelSu.absolutePath
-        val ksudDest = "/data/local/tmp/ksud-pixel"
+        val ksudDest = KernelSuDetector.KSUD_PATH
         val helper = File(app.applicationInfo.nativeLibraryDir, "libcve43499root.so")
 
         // 1. Wait for daemon to be ready
@@ -374,14 +382,32 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
             appendLog(lateResult.output.take(2000))
         }
 
-        // 4. Verify KSU is actually loaded (check multiple paths)
-        var ksuActive = lateResult.code == 0 &&
-            lateResult.output.contains("KernelSU control verified")
+        // 4. Verify KSU is actually loaded. ksud's kernel-side version is the
+        // only check valid on every KMI: on android14-6.1 the node/dir probe
+        // reports success even when the module failed to load. Fall back to the
+        // probe only when ksud cannot answer — dropping /data/adb/ksu from it is
+        // what made a good load look like a failure on android15-6.6.
+        var ksuActive = false
         for (i in 1..10) {
-            if (ksuActive) break
+            // stderr dropped: a missing ksud must read as "no answer", not as a
+            // transient failure to runHelper's retry loop.
+            val version = runHelper(helper, "-c", "$ksudDest debug version 2>/dev/null")
+            val kernelVersion = KernelSuDetector.parseKernelVersion(version.output)
+            if (kernelVersion != null) {
+                if (kernelVersion > 0) {
+                    appendLog("[+] KernelSU verified (attempt $i): kernel version $kernelVersion")
+                    ksuActive = true
+                    break
+                }
+                // Definitive "not live" — do not let the fallback overrule it.
+                Thread.sleep(500)
+                continue
+            }
+
             val check = runHelper(helper, "-c",
                 "test -e /dev/kernelsu && echo KSU_OK || " +
                 "test -e /sys/kernel/kernelsu && echo KSU_OK || " +
+                "test -e /data/adb/ksu && echo KSU_OK || " +
                 "echo KSU_NOT_FOUND")
             if (check.output.contains("KSU_OK")) {
                 appendLog("[+] KernelSU verified (attempt $i): ${check.output.take(60)}")

--- a/app/src/main/kotlin/com/alex193a/rootmypixel/shizuku/ExploitService.kt
+++ b/app/src/main/kotlin/com/alex193a/rootmypixel/shizuku/ExploitService.kt
@@ -6,7 +6,7 @@ import java.io.File
 import java.io.InputStream
 import kotlin.concurrent.thread
 
-class ExploitService : IExploitService.Stub() {
+open class ExploitService : IExploitService.Stub() {
     private var process: java.lang.Process? = null
     private val logBuilder = StringBuilder()
     private var exitCode: Int? = null

--- a/app/src/main/kotlin/com/alex193a/rootmypixel/shizuku/KernelSuDetector.kt
+++ b/app/src/main/kotlin/com/alex193a/rootmypixel/shizuku/KernelSuDetector.kt
@@ -8,9 +8,30 @@ import android.os.IBinder
 import rikka.shizuku.Shizuku
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 
 object KernelSuDetector {
+
+    /** Installs in flight app-wide; probing is suppressed while any is running. */
+    private val installsInFlight = AtomicInteger(0)
+
+    fun beginInstall() {
+        installsInFlight.incrementAndGet()
+    }
+
+    fun endInstall() {
+        installsInFlight.updateAndGet { if (it > 0) it - 1 else 0 }
+    }
+
+    fun isInstallInFlight(): Boolean = installsInFlight.get() > 0
+
+    /**
+     * Whether KernelSU is live *right now*, per ksud's kernel-side version.
+     * Deliberately ignores on-disk paths: `/data/adb/ksu` survives reboots.
+     */
     fun isActive(context: Context): Boolean {
+        if (isInstallInFlight()) return false
+
         val available = runCatching {
             Shizuku.pingBinder() &&
                 Shizuku.isPreV11().not() &&
@@ -20,12 +41,13 @@ object KernelSuDetector {
         if (!available) return false
 
         val args = Shizuku.UserServiceArgs(
-            ComponentName(context.packageName, ExploitService::class.java.name)
+            ComponentName(context.packageName, ProbeService::class.java.name)
         )
             .daemon(false)
-            .processNameSuffix("exploit_service")
+            .processNameSuffix("probe_service")
             .version(1)
         val connected = CountDownLatch(1)
+        // Read only after await() succeeds — that is the happens-before edge.
         var service: IExploitService? = null
         val connection = object : ServiceConnection {
             override fun onServiceConnected(name: ComponentName?, binder: IBinder?) {
@@ -38,20 +60,34 @@ object KernelSuDetector {
             }
         }
 
+        var bound = false
         return try {
             Shizuku.bindUserService(args, connection)
-            connected.await(SERVICE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            bound = true
+            if (!connected.await(SERVICE_TIMEOUT_SECONDS, TimeUnit.SECONDS)) return false
             val output = service?.exec(
-                "/data/local/tmp/ksud-pixel debug version 2>/dev/null || true"
+                "$KSUD_PATH debug version 2>/dev/null || true"
             ).orEmpty()
-            ROOT_VERSION.find(output)?.groupValues?.get(1)?.toIntOrNull()?.let { it > 0 } == true
+            val version = parseKernelVersion(output)
+            version != null && version > 0
         } catch (_: Exception) {
             false
         } finally {
-            runCatching { Shizuku.unbindUserService(args, connection, true) }
+            if (bound) {
+                runCatching { Shizuku.unbindUserService(args, connection, true) }
+            }
         }
     }
 
+    /**
+     * Kernel-side version from `ksud debug version`, or null if ksud did not
+     * answer. Callers rely on null ("no answer") differing from 0 ("not live").
+     */
+    fun parseKernelVersion(output: String): Int? =
+        KERNEL_VERSION.find(output)?.groupValues?.get(1)?.toIntOrNull()
+
+    const val KSUD_PATH = "/data/local/tmp/ksud-pixel"
+
     private const val SERVICE_TIMEOUT_SECONDS = 5L
-    private val ROOT_VERSION = Regex("Kernel Version: ([0-9]+)")
+    private val KERNEL_VERSION = Regex("Kernel Version:\\s*(-?[0-9]+)")
 }

--- a/app/src/main/kotlin/com/alex193a/rootmypixel/shizuku/ProbeService.kt
+++ b/app/src/main/kotlin/com/alex193a/rootmypixel/shizuku/ProbeService.kt
@@ -1,0 +1,7 @@
+package com.alex193a.rootmypixel.shizuku
+
+/**
+ * Probe-only twin of [ExploitService], so unbinding a probe (which destroys the
+ * user service process) can never kill a running exploit or its root daemon.
+ */
+class ProbeService : ExploitService()

--- a/app/src/test/kotlin/com/alex193a/rootmypixel/shizuku/KernelSuDetectorTest.kt
+++ b/app/src/test/kotlin/com/alex193a/rootmypixel/shizuku/KernelSuDetectorTest.kt
@@ -1,0 +1,35 @@
+package com.alex193a.rootmypixel.shizuku
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class KernelSuDetectorTest {
+
+    @Test
+    fun `parses kernel version from ksud output`() {
+        assertEquals(12, KernelSuDetector.parseKernelVersion("Kernel Version: 12"))
+        assertEquals(12, KernelSuDetector.parseKernelVersion("late-load start\nKernel Version: 12\n"))
+        assertEquals(12, KernelSuDetector.parseKernelVersion("Kernel Version:12"))
+    }
+
+    /** Zero means "ksud answered, module not live" and must not read as null. */
+    @Test
+    fun `distinguishes a zero version from no answer`() {
+        assertEquals(0, KernelSuDetector.parseKernelVersion("Kernel Version: 0"))
+        assertEquals(-1, KernelSuDetector.parseKernelVersion("Kernel Version: -1"))
+        assertNull(KernelSuDetector.parseKernelVersion(""))
+        assertNull(KernelSuDetector.parseKernelVersion("sh: ksud-pixel: not found"))
+    }
+
+    @Test
+    fun `install guard suppresses probing`() {
+        KernelSuDetector.beginInstall()
+        try {
+            assert(KernelSuDetector.isInstallInFlight())
+        } finally {
+            KernelSuDetector.endInstall()
+        }
+        assert(!KernelSuDetector.isInstallInFlight())
+    }
+}


### PR DESCRIPTION
Follow-up to #1. Two regressions from that PR are on `main` now, both on the android15-6.6 (Pixel 10) path. @alex193a reported them on a Pixel 10 Pro XL: freeze + device reboot on the first attempt, a ReSukiSU load failure on the second, another reset on the third.

### 1. Probing could destroy a running exploit

`KernelSuDetector` bound the *same* Shizuku UserService that runs the payload — same `ComponentName`, same `processNameSuffix`, same `version` — and released it with `unbindUserService(..., destroy = true)`, which tears the service **process** down.

`InstallActivity.onCreate` starts a probe (via the ViewModel's `init { refresh() }`) and an install back to back. `install()` calls `discoveryJob?.cancel()`, but that does not stop the probe: it is a blocking call with no suspension point, so it runs to completion and destroys the service — possibly while the payload is mid-run. Killing a payload after it has started corrupting kernel state is a plausible source of the freezes and resets, and the race is why three attempts gave three different outcomes.

Probing now uses its own `ProbeService` with its own process name suffix, so tearing a probe down cannot touch the exploit or the root daemon. Installs also suppress probing outright, and `install()` joins discovery before touching Shizuku.

### 2. Verification failed on a load that actually succeeded

The post-late-load check dropped `/data/adb/ksu` — the only one of the three probed paths that matches on Pixel 10 — and seeded its result from:

```kotlin
lateResult.output.contains("KernelSU control verified")
```

ksud never prints that string. It emits `late-load command triggered!`, `KernelSU already loaded, skip loading ko`, `Kernel Version: `. (The app's own string is "ReSukiSU control interface verified".) So the seed was always false and the one matching path was gone — a good load reported as a failure.

Both are replaced by ksud's own kernel-side version, which is non-zero only while the LKM is live and is therefore authoritative on android14-6.1 and android15-6.6 alike. The node probe stays as a fallback for when ksud cannot answer at all, with `/data/adb/ksu` restored.

A parsed `0` ("ksud answered, not live") is kept distinct from no answer, so the fallback cannot overrule a definitive negative — that ambiguity is what made the path probe unreliable on android14-6.1 and prompted the original removal.

### Not changed

`NativeProbe.isKernelSuActive()` is left as-is. Dropping the on-disk paths there was correct: `/data/adb/ksu` survives reboots, so it reports stale root as active.