### PR TITLE
Build the exploit payloads in CI

### DIFF
--- a/.github/workflows/build-debug-apk.yml
+++ b/.github/workflows/build-debug-apk.yml
@@ -55,6 +55,24 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew
 
+      - name: Build native helper and exploit payloads
+        # Regenerates jniLibs/libcve43499root.so and assets/exploits/*.so from
+        # source for every entry in build-all.sh's TARGETS list, so the list
+        # stays the single source of truth for which devices get a payload.
+        run: |
+          chmod +x ./build-all.sh
+          ./build-all.sh --payloads-only
+
+      - name: Upload exploit payloads
+        uses: actions/upload-artifact@v4
+        with:
+          name: exploit-payloads
+          path: |
+            app/src/main/assets/exploits/*.so
+            app/src/main/jniLibs/arm64-v8a/*.so
+          if-no-files-found: error
+          retention-days: 14
+
       - name: Assemble debug APK
         run: ./gradlew assembleDebug --stacktrace
 

--- a/build-all.sh
+++ b/build-all.sh
@@ -12,6 +12,19 @@ set -euo pipefail
 #   - macOS arm64 or Linux x86_64 host
 # ────────────────────────────────────────────────────────────
 
+# ── Options ─────────────────────────────────────────────────
+# --payloads-only stops after the native helper and the exploit payloads.
+# CI uses it to regenerate the binaries from source before the Gradle build
+# runs, so the TARGETS list below stays the single source of truth for which
+# devices get a payload.
+PAYLOADS_ONLY=0
+for arg in "$@"; do
+  case "$arg" in
+    --payloads-only) PAYLOADS_ONLY=1 ;;
+    *) echo "unknown option: $arg" >&2; exit 2 ;;
+  esac
+done
+
 ROOT="$(cd "$(dirname "$0")" && pwd)"
 PAYLOADS="$ROOT/Root-My-Pixel-Payloads"
 APP="$ROOT/app"
@@ -84,6 +97,12 @@ for TARGET in "${TARGETS[@]}"; do
     exit 1
   fi
 done
+
+if [ "$PAYLOADS_ONLY" -eq 1 ]; then
+  echo ""
+  echo "═══ PAYLOADS COMPLETE (--payloads-only, skipping APK) ═══"
+  exit 0
+fi
 
 echo ""
 echo "═══ Step 3/3: Build APK ═══"


### PR DESCRIPTION
Split out of #18, as requested.

`profiles.json` names a payload asset for every supported target, and each one
is committed as a prebuilt blob. That makes the tree the source of truth for the
binaries rather than `build-all.sh`'s `TARGETS` list, so the two can drift — a
target added to `TARGETS` without a committed `.so` ships a profile the app
matches and then cannot extract a payload for.

Regenerate the native helper and every `TARGETS` entry from source before the
Gradle build, via a new `--payloads-only` mode, and upload them as their own
artifact so a build can be inspected without unpacking the APK.

`TARGETS` becomes the single source of truth, and the committed blobs get
refreshed from the pinned payloads submodule on every run rather than trusted.

Verified: CI builds all 13 targets from the pinned submodule and the APK ships
one payload per profile.
