### PR TITLE
Verify KernelSU by asking the kernel, and register the manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ Root My Pixel lets you *temporarily* gain root access with ReSukiSU in just one 
 4. **KernelSU / ReSukiSU Integration**
    - Staging of the `ksud` binary matching the device's Kernel Module Interface (KMI, e.g., `android15-6.6`).
    - The app triggers the KernelSU **late-load** mechanism (`ksud late-load --kmi <kmi>`).
-   - Verifies KernelSU active status by probing kernel device nodes (`/dev/kernelsu`, `/sys/kernel/kernelsu`, `/data/adb/ksu`).
+   - Verifies KernelSU active status by asking the module itself (`ksud debug info`, falling back to `/proc/modules`).
+   - Registers the installed ReSukiSU Manager's APK signature with the module (`ksud kernel dynamic-manager set-apk`) so it can grant root.
 
 5. **User Interface & Management Tools**
    - Real-time live log progress monitoring.

--- a/app/src/main/kotlin/com/alex193a/rootmypixel/feature/install/InstallViewModel.kt
+++ b/app/src/main/kotlin/com/alex193a/rootmypixel/feature/install/InstallViewModel.kt
@@ -373,29 +373,75 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
             appendLog(lateResult.output.take(2000))
         }
 
-        // 4. Verify KSU is actually loaded (check multiple paths)
-        var ksuActive = false
+        // 4. Verify the module is live by asking the kernel, not by probing
+        //    paths. /dev/kernelsu, /sys/kernel/kernelsu and /data/adb/ksu are
+        //    none of them created by ReSukiSU in LKM mode, so this reported
+        //    failure on a device where the module had loaded and root worked.
+        //    `ksud debug info` answers through the module's own prctl
+        //    interface; /proc/modules is the backstop.
+        var ksuInfo: String? = null
         for (i in 1..10) {
             val check = runHelper(helper, "-c",
-                "test -e /dev/kernelsu && echo KSU_OK || " +
-                "test -e /sys/kernel/kernelsu && echo KSU_OK || " +
-                "test -e /data/adb/ksu && echo KSU_OK || " +
-                "echo KSU_NOT_FOUND")
-            if (check.output.contains("KSU_OK")) {
-                appendLog("[+] KernelSU verified (attempt $i): ${check.output.take(60)}")
-                ksuActive = true
+                "if $ksudDest debug info 2>/dev/null | grep -qE '^version: [1-9]'; then " +
+                "$ksudDest debug info 2>/dev/null; " +
+                "elif grep -q '^kernelsu ' /proc/modules; then " +
+                "grep '^kernelsu ' /proc/modules; " +
+                "else echo KSU_NOT_FOUND; fi")
+            if (!check.output.contains("KSU_NOT_FOUND") && check.output.isNotBlank()) {
+                appendLog("[+] KernelSU verified (attempt $i):\n${check.output.take(400)}")
+                ksuInfo = check.output
                 break
             }
             Thread.sleep(500)
         }
-        require(ksuActive) {
+        require(ksuInfo != null) {
             app.getString(
                 R.string.error_ksu_verify,
                 lateResult.code,
                 lateResult.output.take(200)
             )
         }
+
+        // 5. Point the module at the manager that is actually installed.
+        //    ReSukiSU authenticates its manager by APK signature, and the ko
+        //    bundled here cannot know the signature of a manager the user
+        //    installed separately — the normal case, since the manager ships
+        //    on its own cadence. Without this the module is live but the
+        //    manager shows "not installed" and can grant nothing.
+        registerManager(helper, ksudDest)
+
         appendLog(app.getString(R.string.log_ksu_control_verified))
+    }
+
+    /**
+     * Registers the installed ReSukiSU manager's APK signature with the loaded
+     * module, so it can recognise the manager and grant root through it.
+     *
+     * Not fatal on failure: the module is loaded and root works either way, and
+     * a manager can also be pointed at it by hand.
+     */
+    private fun registerManager(helper: File, ksudDest: String) {
+        val apkPath = runCatching {
+            app.packageManager
+                .getPackageInfo(RESUKISU_PACKAGE, 0)
+                .applicationInfo
+                ?.sourceDir
+        }.getOrNull()
+
+        if (apkPath.isNullOrBlank()) {
+            appendLog("[!] ReSukiSU manager not installed — skipping signature registration")
+            return
+        }
+
+        appendLog("[*] Registering the ReSukiSU manager with the module...")
+        val set = runHelper(helper, "-c",
+            "$ksudDest kernel dynamic-manager set-apk '$apkPath'")
+        if (set.code != 0) {
+            appendLog("[!] Manager registration failed (${set.code}): ${set.output.take(200)}")
+            return
+        }
+        val got = runHelper(helper, "-c", "$ksudDest kernel dynamic-manager get")
+        appendLog("[+] Manager registered: ${got.output.trim().take(200)}")
     }
 
     private fun runHelper(helper: File, vararg arguments: String): CommandResult {
@@ -491,5 +537,7 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
         private const val EXPLOIT_TOTAL_MILLIS = 1_800_000L
         private const val MAX_LOG_CHARS = 5 * 1024 * 1024
         private val LOG_POLL_INTERVAL = 250.milliseconds
+
+        private const val RESUKISU_PACKAGE = "com.resukisu.resukisu"
     }
 }


### PR DESCRIPTION
Split out of #18, as requested.

Two problems that between them made a working install report failure.

**The verification probed paths that ReSukiSU does not create.**
`/dev/kernelsu`, `/sys/kernel/kernelsu` and `/data/adb/ksu` are none of them
created in LKM mode, so on a Pixel 9a where the module had loaded and
`su -c id` returned `uid=0(root)` the app still said "Installation failed".

Ask the module instead — `ksud debug info` answers through its own prctl
interface, with `/proc/modules` as the backstop. What the kernel reported now
goes into the log, so a real failure says something useful:

```
version: 35040
full_version: v4.1.0-88dbc786@ReSukiSU
lkm: true
runtime_mode: late-load
```

**The manager was not registered with the module.** ReSukiSU authenticates its
manager by APK signature, and the `.ko` bundled here cannot know the signature
of a manager the user installed separately — the normal case, since the manager
ships on its own cadence. On that same device the module was live while the
manager showed "not installed" and could grant nothing.

Hand it the installed manager's APK after late-load via
`ksud kernel dynamic-manager set-apk`. Not fatal if it fails: the module is
loaded and root works either way.

### Verified

On a physical Pixel 9a, after `set-apk` the manager comes up as working
(LKM / Jailbreak mode) instead of "not installed", and `/proc/modules` shows
`kernelsu … Live` with the refcount rising as the manager attaches.
