### PR TITLE
Support modern ReSukiSU root detection

### DIFF
--- a/app/src/main/kotlin/com/alex193a/rootmypixel/feature/install/InstallViewModel.kt
+++ b/app/src/main/kotlin/com/alex193a/rootmypixel/feature/install/InstallViewModel.kt
@@ -19,6 +19,7 @@ import com.alex193a.rootmypixel.domain.usecase.DownloadPayloadsUseCase
 import com.alex193a.rootmypixel.domain.usecase.ResolveTargetUseCase
 import com.alex193a.rootmypixel.shizuku.ExploitService
 import com.alex193a.rootmypixel.shizuku.IExploitService
+import com.alex193a.rootmypixel.shizuku.KernelSuDetector
 import com.alex193a.rootmypixel.utils.NativeProbe
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -67,7 +68,7 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
             try {
                 val probe = NativeProbe.run()
                 val deviceInfo = NativeProbe.readDeviceSnapshot()
-                if (NativeProbe.isKernelSuActive()) {
+                if (NativeProbe.isKernelSuActive() || KernelSuDetector.isActive(app)) {
                     mutableState.value = InstallUiState(
                         phase = InstallPhase.Installed,
                         message = app.getString(R.string.status_ksu_active),
@@ -367,15 +368,24 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
 
         // 3. Execute late-load via daemon root
         appendLog("[*] Triggering KernelSU late-load (kmi=${payloads.kmi})...")
-        val lateResult = runHelper(helper, "-c",
-            "$ksudDest late-load --kmi ${payloads.kmi}")
+        val lateResult = runHelper(
+            helper,
+            "-c",
+            "$ksudDest late-load --allow-shell --kmi ${payloads.kmi} " +
+                "--package-name com.resukisu.resukisu",
+        )
         if (lateResult.output.isNotBlank()) {
             appendLog(lateResult.output.take(2000))
         }
 
-        // 4. Verify KSU is actually loaded (check multiple paths)
-        var ksuActive = false
+        // 4. Verify modern fd-based ReSukiSU via its shell su interface.
+        // Keep legacy node checks as a fallback for older KernelSU builds.
+        var ksuActive = KernelSuDetector.isActive(app)
+        if (ksuActive) {
+            appendLog("[+] KernelSU verified through shell su interface")
+        }
         for (i in 1..10) {
+            if (ksuActive) break
             val check = runHelper(helper, "-c",
                 "test -e /dev/kernelsu && echo KSU_OK || " +
                 "test -e /sys/kernel/kernelsu && echo KSU_OK || " +

--- a/app/src/main/kotlin/com/alex193a/rootmypixel/feature/main/MainViewModel.kt
+++ b/app/src/main/kotlin/com/alex193a/rootmypixel/feature/main/MainViewModel.kt
@@ -18,6 +18,7 @@ import com.alex193a.rootmypixel.domain.model.InstallPhase
 import com.alex193a.rootmypixel.domain.model.InstallUiState
 import com.alex193a.rootmypixel.domain.usecase.ResolveTargetUseCase
 import com.alex193a.rootmypixel.feature.install.InstallActivity
+import com.alex193a.rootmypixel.shizuku.KernelSuDetector
 import com.alex193a.rootmypixel.utils.NativeProbe
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -112,7 +113,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                 mutableReSukiSuInstalled.value = app.packageManager
                     .getLaunchIntentForPackage("com.resukisu.resukisu") != null
                 val probe = NativeProbe.run()
-                if (NativeProbe.isKernelSuActive()) {
+                if (NativeProbe.isKernelSuActive() || KernelSuDetector.isActive(app)) {
                     mutableState.value = InstallUiState(
                         phase = InstallPhase.Installed,
                         message = app.getString(R.string.status_ksu_active),

--- a/app/src/main/kotlin/com/alex193a/rootmypixel/shizuku/KernelSuDetector.kt
+++ b/app/src/main/kotlin/com/alex193a/rootmypixel/shizuku/KernelSuDetector.kt
@@ -1,0 +1,85 @@
+package com.alex193a.rootmypixel.shizuku
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.ServiceConnection
+import android.content.pm.PackageManager
+import android.os.IBinder
+import rikka.shizuku.Shizuku
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+/** Detects modern ReSukiSU through its su interface instead of legacy nodes. */
+object KernelSuDetector {
+    fun isActive(context: Context): Boolean {
+        if (isDirectAppSuActive()) return true
+        return isShizukuShellSuActive(context)
+    }
+
+    private fun isDirectAppSuActive(): Boolean = runCatching {
+        val process = ProcessBuilder(
+            "/system/bin/su",
+            "-c",
+            "echo $PROBE_MARKER; id -u",
+        ).redirectErrorStream(true).start()
+        if (!process.waitFor(PROBE_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+            process.destroyForcibly()
+            process.waitFor(1, TimeUnit.SECONDS)
+            return@runCatching false
+        }
+        isRootShellProbeOutput(process.inputStream.bufferedReader().use { it.readText() })
+    }.getOrDefault(false)
+
+    private fun isShizukuShellSuActive(context: Context): Boolean {
+        val shizukuReady = runCatching {
+            Shizuku.pingBinder() &&
+                !Shizuku.isPreV11() &&
+                Shizuku.getUid() == 2000 &&
+                Shizuku.checkSelfPermission() == PackageManager.PERMISSION_GRANTED
+        }.getOrDefault(false)
+        if (!shizukuReady) return false
+
+        val args = Shizuku.UserServiceArgs(
+            ComponentName(context.packageName, ExploitService::class.java.name),
+        )
+            .daemon(false)
+            .processNameSuffix("ksu_detector")
+            .version(1)
+        val connected = CountDownLatch(1)
+        var service: IExploitService? = null
+        val connection = object : ServiceConnection {
+            override fun onServiceConnected(name: ComponentName?, binder: IBinder?) {
+                service = IExploitService.Stub.asInterface(binder)
+                connected.countDown()
+            }
+
+            override fun onServiceDisconnected(name: ComponentName?) {
+                service = null
+            }
+        }
+
+        return try {
+            Shizuku.bindUserService(args, connection)
+            if (!connected.await(SERVICE_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                false
+            } else {
+                isRootShellProbeOutput(service?.exec(ROOT_PROBE_COMMAND).orEmpty())
+            }
+        } catch (_: Exception) {
+            false
+        } finally {
+            runCatching { Shizuku.unbindUserService(args, connection, true) }
+        }
+    }
+
+    internal fun isRootShellProbeOutput(output: String): Boolean {
+        val lines = output.lineSequence().map(String::trim).filter(String::isNotEmpty).toSet()
+        return PROBE_MARKER in lines && "0" in lines
+    }
+
+    private const val SERVICE_TIMEOUT_SECONDS = 5L
+    private const val PROBE_TIMEOUT_SECONDS = 5L
+    private const val PROBE_MARKER = "ROOT_MY_PIXEL_KSU_ACTIVE"
+    private const val ROOT_PROBE_COMMAND =
+        "/system/bin/su -c 'echo $PROBE_MARKER; id -u' </dev/null 2>/dev/null"
+}

--- a/app/src/test/kotlin/com/alex193a/rootmypixel/shizuku/KernelSuDetectorTest.kt
+++ b/app/src/test/kotlin/com/alex193a/rootmypixel/shizuku/KernelSuDetectorTest.kt
@@ -1,0 +1,27 @@
+package com.alex193a.rootmypixel.shizuku
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class KernelSuDetectorTest {
+    @Test
+    fun acceptsSuccessfulRootProbe() {
+        assertTrue(
+            KernelSuDetector.isRootShellProbeOutput(
+                "ROOT_MY_PIXEL_KSU_ACTIVE\n0\n",
+            ),
+        )
+    }
+
+    @Test
+    fun rejectsUnprivilegedOrIncompleteProbe() {
+        assertFalse(
+            KernelSuDetector.isRootShellProbeOutput(
+                "ROOT_MY_PIXEL_KSU_ACTIVE\n2000\n",
+            ),
+        )
+        assertFalse(KernelSuDetector.isRootShellProbeOutput("0\n"))
+        assertFalse(KernelSuDetector.isRootShellProbeOutput(""))
+    }
+}


### PR DESCRIPTION
## Summary

- enables shell access for modern ReSukiSU late-loads and specifies the ReSukiSU manager package
- detects fd-based ReSukiSU installations with a bounded root-shell probe, using direct app `su` first and a Shizuku shell user-service fallback
- retains the existing legacy KernelSU node checks as a fallback
- adds unit coverage for successful, unprivileged, and incomplete probe output

## Validation

```text
./gradlew testDebugUnitTest --no-daemon
```

`BUILD SUCCESSFUL`
