### PR TITLE
fix: verify ReSukiSU late-load and manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ Root My Pixel lets you *temporarily* gain root access with ReSukiSU in just one 
 4. **KernelSU / ReSukiSU Integration**
    - Staging of the `ksud` binary matching the device's Kernel Module Interface (KMI, e.g., `android15-6.6`).
    - The app triggers the KernelSU **late-load** mechanism (`ksud late-load --kmi <kmi>`).
-   - Verifies KernelSU active status by probing kernel device nodes (`/dev/kernelsu`, `/sys/kernel/kernelsu`, `/data/adb/ksu`).
+   - Verifies KernelSU through its UAPI, with `ksud debug info` and `/proc/modules` as compatibility fallbacks.
+   - Registers the installed ReSukiSU Manager only after validating its production APK signature.
 
 5. **User Interface & Management Tools**
    - Real-time live log progress monitoring.

--- a/app/src/main/kotlin/com/alex193a/rootmypixel/feature/install/InstallViewModel.kt
+++ b/app/src/main/kotlin/com/alex193a/rootmypixel/feature/install/InstallViewModel.kt
@@ -20,6 +20,7 @@ import com.alex193a.rootmypixel.domain.usecase.DownloadPayloadsUseCase
 import com.alex193a.rootmypixel.domain.usecase.ResolveTargetUseCase
 import com.alex193a.rootmypixel.shizuku.ExploitService
 import com.alex193a.rootmypixel.shizuku.IExploitService
+import com.alex193a.rootmypixel.utils.KernelSuInstallChecks
 import com.alex193a.rootmypixel.utils.NativeProbe
 import com.alex193a.rootmypixel.utils.UnrootCommandOutcome
 import com.alex193a.rootmypixel.utils.UnrootIssue
@@ -388,30 +389,146 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
             appendLog(lateResult.output.take(2000))
         }
 
-        // 4. Verify KSU is actually loaded (check multiple paths)
-        var ksuActive = false
-        for (i in 1..10) {
-            val check = runHelper(helper, "-c",
-                "test -e /dev/kernelsu && echo KSU_OK || " +
-                "test -e /sys/kernel/kernelsu && echo KSU_OK || " +
-                "test -e /data/adb/ksu && echo KSU_OK || " +
-                "echo KSU_NOT_FOUND")
-            if (check.output.contains("KSU_OK")) {
-                appendLog("[+] KernelSU verified (attempt $i): ${check.output.take(60)}")
-                ksuActive = true
-                break
-            }
-            Thread.sleep(500)
-        }
-        require(ksuActive) {
-            app.getString(
-                R.string.error_ksu_verify,
-                lateResult.code,
-                lateResult.output.take(200)
-            )
-        }
+        // 4. Verify the driver itself. ReSukiSU LKM mode does not create the
+        // legacy filesystem paths that were previously probed here.
+        verifyKernelSuLoaded(helper, ksudDest, lateResult)
+
+        // 5. Register only a known ReSukiSU production manager signature.
+        // Package name alone is not a sufficient trust boundary for a root manager.
+        registerManager(helper, ksudDest)
+
         appendLog(app.getString(R.string.log_ksu_control_verified))
     }
+
+    private fun verifyKernelSuLoaded(
+        helper: File,
+        ksudDest: String,
+        lateResult: CommandResult,
+    ) {
+        var nativeStatus = NativeProbe.KernelSuStatus()
+        var debugResult = CommandResult(-1, "not attempted")
+        var moduleResult = CommandResult(-1, "not attempted")
+
+        for (attempt in 1..10) {
+            nativeStatus = NativeProbe.kernelSuStatus()
+            if (nativeStatus.isActive) {
+                appendLog(
+                    "[+] KernelSU verified through UAPI (attempt $attempt): " +
+                        "version=${nativeStatus.version} flags=0x${nativeStatus.flags.toString(16)} " +
+                        "uapi=${nativeStatus.uapiVersion}",
+                )
+                return
+            }
+
+            debugResult = runHelper(helper, "-c", "$ksudDest debug info")
+            if (debugResult.code == 0 &&
+                KernelSuInstallChecks.debugInfoShowsActiveKernelSu(debugResult.output)
+            ) {
+                appendLog(
+                    "[+] KernelSU verified through ksud (attempt $attempt):\n" +
+                        debugResult.output.take(500),
+                )
+                return
+            }
+
+            moduleResult = runHelper(helper, "-c", "grep '^kernelsu ' /proc/modules")
+            if (moduleResult.code == 0 &&
+                KernelSuInstallChecks.procModulesShowsActiveKernelSu(moduleResult.output)
+            ) {
+                appendLog(
+                    "[+] KernelSU verified through /proc/modules (attempt $attempt): " +
+                        moduleResult.output.take(200),
+                )
+                return
+            }
+
+            Thread.sleep(500)
+        }
+
+        val diagnostics = buildString {
+            append("late-load output: ")
+            append(lateResult.output.ifBlank { "<empty>" }.take(300))
+            append("; native probe: present=${nativeStatus.driverPresent}, ")
+            append("responsive=${nativeStatus.driverResponsive}, version=${nativeStatus.version}")
+            append("; ksud debug (${debugResult.code}): ")
+            append(debugResult.output.ifBlank { "<empty>" }.take(300))
+            append("; /proc/modules (${moduleResult.code}): ")
+            append(moduleResult.output.ifBlank { "<empty>" }.take(200))
+        }
+        throw IllegalStateException(
+            app.getString(R.string.error_ksu_verify, lateResult.code, diagnostics),
+        )
+    }
+
+    private fun registerManager(helper: File, ksudDest: String) {
+        val apkPath = runCatching {
+            app.packageManager.getApplicationInfo(
+                RESUKISU_PACKAGE,
+                PackageManager.ApplicationInfoFlags.of(0),
+            ).sourceDir
+        }.getOrNull()
+
+        if (apkPath.isNullOrBlank()) {
+            appendLog("[!] ReSukiSU manager not installed — skipping registration")
+            return
+        }
+
+        appendLog("[*] Verifying the installed ReSukiSU manager signature...")
+        val signatureResult = runHelper(
+            helper,
+            "-c",
+            "$ksudDest debug get-sign ${shellQuote(apkPath)}",
+        )
+        if (signatureResult.code != 0) {
+            appendLog(
+                "[!] Manager signature verification failed (${signatureResult.code}): " +
+                    signatureResult.output.ifBlank { "no output" }.take(200),
+            )
+            return
+        }
+
+        val signature = KernelSuInstallChecks.parseManagerSignature(signatureResult.output)
+        if (signature == null || !KernelSuInstallChecks.isTrustedManagerSignature(signature)) {
+            appendLog(
+                "[!] Installed manager signature is not trusted; registration skipped: " +
+                    signatureResult.output.ifBlank { "unrecognised output" }.take(200),
+            )
+            return
+        }
+
+        appendLog("[*] Registering the ReSukiSU manager with the module...")
+        val setResult = runHelper(
+            helper,
+            "-c",
+            "$ksudDest kernel dynamic-manager set ${signature.size} ${signature.hash}",
+        )
+        if (setResult.code != 0) {
+            appendLog(
+                "[!] Manager registration failed (${setResult.code}): " +
+                    setResult.output.ifBlank { "no output" }.take(200),
+            )
+            return
+        }
+
+        val getResult = runHelper(helper, "-c", "$ksudDest kernel dynamic-manager get")
+        val registeredSignature = if (getResult.code == 0) {
+            KernelSuInstallChecks.parseManagerSignature(getResult.output)
+        } else {
+            null
+        }
+        if (registeredSignature != signature) {
+            appendLog(
+                "[!] Manager registration could not be confirmed (${getResult.code}): " +
+                    getResult.output.ifBlank { "no output" }.take(200),
+            )
+            return
+        }
+
+        appendLog("[+] ReSukiSU manager registered and verified")
+    }
+
+    private fun shellQuote(value: String): String =
+        "'${value.replace("'", "'\"'\"'")}'"
 
     private fun runHelper(helper: File, vararg arguments: String): CommandResult {
         for (attempt in 1..5) {
@@ -633,6 +750,7 @@ class InstallViewModel(application: Application) : AndroidViewModel(application)
         private const val COMMAND_TIMEOUT_SECONDS = 90L
         private const val COMMAND_TIMEOUT_CODE = 124
         private val LOG_POLL_INTERVAL = 250.milliseconds
+        private const val RESUKISU_PACKAGE = "com.resukisu.resukisu"
         private const val REBOOT_COMMAND =
             "sync; if svc power reboot || reboot; then " +
                     "echo UNROOT_REBOOT_REQUESTED; else echo UNROOT_FAIL:reboot:${'$'}?; fi"

--- a/app/src/main/kotlin/com/alex193a/rootmypixel/utils/KernelSuInstallChecks.kt
+++ b/app/src/main/kotlin/com/alex193a/rootmypixel/utils/KernelSuInstallChecks.kt
@@ -1,0 +1,45 @@
+package com.alex193a.rootmypixel.utils
+
+internal object KernelSuInstallChecks {
+    private val versionLine = Regex("(?m)^version:\\s*([1-9][0-9]*)\\s*$")
+    private val kernelModuleLine = Regex("(?m)^kernelsu\\s+.+$")
+    private val signatureLine = Regex(
+        """^size:\s*(0[xX][0-9a-fA-F]+|[0-9]+),\s*hash:\s*([0-9a-fA-F]{64})$""",
+    )
+
+    data class ManagerSignature(
+        val size: Int,
+        val hash: String,
+    )
+
+    fun debugInfoShowsActiveKernelSu(output: String): Boolean =
+        versionLine.containsMatchIn(output)
+
+    fun procModulesShowsActiveKernelSu(output: String): Boolean =
+        kernelModuleLine.containsMatchIn(output)
+
+    fun parseManagerSignature(output: String): ManagerSignature? {
+        val match = signatureLine.matchEntire(output.trim()) ?: return null
+        val rawSize = match.groupValues[1]
+        val size = if (rawSize.startsWith("0x", ignoreCase = true)) {
+            rawSize.drop(2).toIntOrNull(16)
+        } else {
+            rawSize.toIntOrNull()
+        } ?: return null
+
+        return ManagerSignature(
+            size = size,
+            hash = match.groupValues[2].lowercase(),
+        )
+    }
+
+    fun isTrustedManagerSignature(signature: ManagerSignature): Boolean =
+        signature in TRUSTED_MANAGER_SIGNATURES
+
+    private val TRUSTED_MANAGER_SIGNATURES = setOf(
+        ManagerSignature(
+            size = 0x377,
+            hash = "d3469712b6214462764a1d8d3e5cbe1d6819a0b629791b9f4101867821f1df64",
+        ),
+    )
+}

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -92,7 +92,7 @@
     <string name="error_payload_exit">L\'exploit è uscito con codice %1$d%2$s</string>
     <string name="error_success_marker">L\'exploit non ha segnalato il successo</string>
     <string name="error_ksu_stage">Impossibile preparare ksud: %1$s</string>
-    <string name="error_ksu_verify">Caricamento di ReSukiSU non riuscito (%1$d): %2$s</string>
+    <string name="error_ksu_verify">Verifica di ReSukiSU non riuscita dopo il late-load (codice %1$d): %2$s</string>
     <string name="error_shizuku_required">Shizuku è richiesto. Installa Shizuku da Google Play e concedi le autorizzazioni a Root My Pixel.</string>
     <string name="error_boot_id">Impossibile leggere l\'ID di avvio</string>
     <string name="error_receipt">Impossibile salvare la ricevuta di installazione</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -104,7 +104,7 @@
     <string name="error_payload_exit">exploit が終了コード %1$d で終了しました%2$s</string>
     <string name="error_success_marker">exploit が成功を報告しませんでした</string>
     <string name="error_ksu_stage">ksud の配置に失敗しました: %1$s</string>
-    <string name="error_ksu_verify">ReSukiSU のローダーが失敗しました (%1$d): %2$s</string>
+    <string name="error_ksu_verify">late-load 後の ReSukiSU 検証に失敗しました (終了コード %1$d): %2$s</string>
     <string name="error_shizuku_required">Shizuku が必要です。Google Play から Shizuku をインストールし、Root My Pixel に権限を許可してください。</string>
     <string name="error_boot_id">boot ID を読み取れません</string>
     <string name="error_receipt">インストール記録を保存できません</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -94,7 +94,7 @@
     <string name="error_payload_exit">漏洞利用程式已結束，結束代碼：%1$d%2$s</string>
     <string name="error_success_marker">漏洞利用程式未回報成功</string>
     <string name="error_ksu_stage">無法準備 ksud: %1$s</string>
-    <string name="error_ksu_verify">ReSukiSU 載入器失敗 (%1$d): %2$s</string>
+    <string name="error_ksu_verify">ReSukiSU 在 late-load 後驗證失敗（結束代碼 %1$d）：%2$s</string>
     <string name="error_shizuku_required">需要 Shizuku。請從 Google Play 安裝 Shizuku，並授予 Root My Pixel 所需權限。</string>
     <string name="error_boot_id">無法讀取 boot ID</string>
     <string name="error_receipt">無法儲存安裝紀錄</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -94,7 +94,7 @@
     <string name="error_payload_exit">Exploit exited with code %1$d%2$s</string>
     <string name="error_success_marker">Exploit did not report success</string>
     <string name="error_ksu_stage">Failed to stage ksud: %1$s</string>
-    <string name="error_ksu_verify">ReSukiSU loader failed (%1$d): %2$s</string>
+    <string name="error_ksu_verify">ReSukiSU verification failed after late-load (exit %1$d): %2$s</string>
     <string name="error_shizuku_required">Shizuku is required. Install Shizuku from Google Play and grant permissions to Root My Pixel.</string>
     <string name="error_boot_id">Cannot read boot ID</string>
     <string name="error_receipt">Cannot persist install receipt</string>

--- a/app/src/test/kotlin/com/alex193a/rootmypixel/utils/KernelSuInstallChecksTest.kt
+++ b/app/src/test/kotlin/com/alex193a/rootmypixel/utils/KernelSuInstallChecksTest.kt
@@ -1,0 +1,60 @@
+package com.alex193a.rootmypixel.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class KernelSuInstallChecksTest {
+
+    @Test
+    fun `debug info requires a positive KernelSU version`() {
+        assertTrue(
+            KernelSuInstallChecks.debugInfoShowsActiveKernelSu(
+                """
+                version: 35040
+                full_version: v4.1.0-88dbc786@ReSukiSU
+                runtime_mode: late-load
+                """.trimIndent(),
+            ),
+        )
+        assertFalse(KernelSuInstallChecks.debugInfoShowsActiveKernelSu("version: 0"))
+        assertFalse(KernelSuInstallChecks.debugInfoShowsActiveKernelSu("connection refused"))
+    }
+
+    @Test
+    fun `proc modules fallback requires the exact kernelsu module`() {
+        assertTrue(
+            KernelSuInstallChecks.procModulesShowsActiveKernelSu(
+                "kernelsu 114688 1 - Live 0x0000000000000000",
+            ),
+        )
+        assertFalse(
+            KernelSuInstallChecks.procModulesShowsActiveKernelSu(
+                "not_kernelsu 114688 1 - Live 0x0000000000000000",
+            ),
+        )
+    }
+
+    @Test
+    fun `trusted ReSukiSU manager signature is parsed from ksud output`() {
+        val signature = KernelSuInstallChecks.parseManagerSignature(
+            "size: 0x377, hash: d3469712b6214462764a1d8d3e5cbe1d6819a0b629791b9f4101867821f1df64",
+        )
+
+        assertEquals(0x377, signature?.size)
+        assertTrue(signature != null && KernelSuInstallChecks.isTrustedManagerSignature(signature))
+    }
+
+    @Test
+    fun `unknown or malformed manager signatures are rejected`() {
+        val unknown = KernelSuInstallChecks.parseManagerSignature(
+            "size: 887, hash: a3469712b6214462764a1d8d3e5cbe1d6819a0b629791b9f4101867821f1df64",
+        )
+
+        assertTrue(unknown != null)
+        assertFalse(KernelSuInstallChecks.isTrustedManagerSignature(unknown!!))
+        assertNull(KernelSuInstallChecks.parseManagerSignature("signature unavailable"))
+    }
+}


### PR DESCRIPTION
Supersedes #26.

This implementation is based on the diagnosis, proposed solution, and
physical-device testing contributed by @serkenn in #26.

It preserves the original intent while resolving the conflicts with the
current main branch, reusing the native KernelSU UAPI probe, improving
failure diagnostics, and validating the manager signature before registration.